### PR TITLE
feat: add abcd concatenator utility

### DIFF
--- a/concat_abcd.py
+++ b/concat_abcd.py
@@ -1,0 +1,16 @@
+class ABCDConcatenator:
+    """Concatenate four values into a single string."""
+
+    def concatenate(self, a, b, c, d):
+        return f"{a}{b}{c}{d}"
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 5:
+        raise SystemExit("Usage: python concat_abcd.py a b c d")
+
+    concatenator = ABCDConcatenator()
+    result = concatenator.concatenate(*sys.argv[1:])
+    print(result)


### PR DESCRIPTION
Introduced `ABCDConcatenator` class and CLI helper that joins four inputs into a single string `abcd`.

- Implemented reusable `concatenate(a, b, c, d)` method and a small `__main__` block for CLI usage
- Why: fulfills the requirement to produce the combined output from four provided arguments
- Technical: uses an f-string for straightforward concatenation and validates argument count before execution
- Impact: standalone addition; no changes to existing modules or behavior