### PR TITLE
feat: add ModuloSubtractAdd class for (a%b)-c+d calculation

### DIFF
--- a/modulo_subtract_add.py
+++ b/modulo_subtract_add.py
@@ -1,0 +1,66 @@
+class ModuloSubtractAdd:
+    """
+    A calculator class that computes (a % b) - c + d
+    """
+
+    def __init__(self, a, b, c, d):
+        """
+        Initialize the calculator with four numbers
+
+        Args:
+            a: First number (dividend)
+            b: Second number (divisor for modulo)
+            c: Third number (subtrahend)
+            d: Fourth number (addend)
+        """
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+
+    def calculate(self):
+        """
+        Calculate and return (a % b) - c + d
+
+        Returns:
+            The result of (a % b) - c + d
+
+        Raises:
+            ZeroDivisionError: If b is zero
+        """
+        if self.b == 0:
+            raise ZeroDivisionError("Cannot perform modulo with zero divisor")
+        return (self.a % self.b) - self.c + self.d
+
+
+# Example usage
+if __name__ == "__main__":
+    print("=== Testing calculate() method ((a % b) - c + d) ===")
+
+    # Test case 1: 10 % 3 - 2 + 5 = 1 - 2 + 5 = 4
+    calc1 = ModuloSubtractAdd(10, 3, 2, 5)
+    result1 = calc1.calculate()
+    print(f"(10 % 3) - 2 + 5 = {result1}")  # Output: 4
+
+    # Test case 2: 17 % 5 - 1 + 8 = 2 - 1 + 8 = 9
+    calc2 = ModuloSubtractAdd(17, 5, 1, 8)
+    result2 = calc2.calculate()
+    print(f"(17 % 5) - 1 + 8 = {result2}")  # Output: 9
+
+    # Test case 3: 20 % 7 - 3 + 10 = 6 - 3 + 10 = 13
+    calc3 = ModuloSubtractAdd(20, 7, 3, 10)
+    result3 = calc3.calculate()
+    print(f"(20 % 7) - 3 + 10 = {result3}")  # Output: 13
+
+    # Test case 4: 15 % 4 - 5 + 2 = 3 - 5 + 2 = 0
+    calc4 = ModuloSubtractAdd(15, 4, 5, 2)
+    result4 = calc4.calculate()
+    print(f"(15 % 4) - 5 + 2 = {result4}")  # Output: 0
+
+    # Test zero division error
+    print("\n=== Testing zero division error ===")
+    try:
+        calc5 = ModuloSubtractAdd(10, 0, 5, 3)
+        result5 = calc5.calculate()
+    except ZeroDivisionError as e:
+        print(f"Error caught: {e}")


### PR DESCRIPTION
## Summary
- Added new `ModuloSubtractAdd` class in `modulo_subtract_add.py` that performs the calculation `(a % b) - c + d`
- Implements proper error handling for zero divisor in modulo operation
- Includes comprehensive test cases demonstrating various scenarios

## What Changed
Created a new Python class that:
- Takes four parameters (a, b, c, d) in the constructor
- Provides a `calculate()` method that returns `(a % b) - c + d`
- Raises `ZeroDivisionError` when b is zero to prevent invalid modulo operations
- Follows the same code structure and documentation style as existing classes in the project (e.g., `DivisionMultiplyAdd`)

## Test Cases
The implementation includes 5 test cases:
1. `(10 % 3) - 2 + 5 = 4`
2. `(17 % 5) - 1 + 8 = 9`
3. `(20 % 7) - 3 + 10 = 13`
4. `(15 % 4) - 5 + 2 = 0`
5. Zero division error handling

All tests pass successfully.

## Design Decisions
- Used class-based approach to match the project's existing pattern (similar to `DivisionMultiplyAdd` class)
- Added zero divisor validation to ensure robust error handling
- Included detailed docstrings for better code documentation